### PR TITLE
Fix submit multipart form error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "symfony/process": "~2.1"
     },
     "require-dev": {
-        "silex/silex": "1.0.*@dev"
+        "silex/silex": "1.0.*@dev",
+        "symfony/browser-kit": "2.2.*"
     },
     "autoload": {
         "psr-0": { "Igorw": "src" }

--- a/src/Igorw/CgiHttpKernel/CgiHttpKernel.php
+++ b/src/Igorw/CgiHttpKernel/CgiHttpKernel.php
@@ -217,9 +217,11 @@ class CgiHttpKernel implements HttpKernelInterface
 
         $data = '';
         foreach ($files->all() as $name => $file) {
-            $data .= $mimeBoundary;
-            $data .= $this->encodeMultipartFile($name, $file);
-            $data .= $mimeBoundary;
+            if ($file) {
+                $data .= $mimeBoundary;
+                $data .= $this->encodeMultipartFile($name, $file);
+                $data .= $mimeBoundary;
+            }
         }
         $data .= "\r\n";
 

--- a/tests/functional/CgiHttpKernelTest.php
+++ b/tests/functional/CgiHttpKernelTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Igorw\CgiHttpKernel\CgiHttpKernel;
+use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -231,6 +233,25 @@ class CgiHttpKernelTest extends \PHPUnit_Framework_TestCase
             '1',
         ));
         $this->assertSame($expected."\n", $response->getContent());
+    }
+
+    /** @test */
+    public function submitShouldUploadOnlySelectedFiles()
+    {
+        $file = new UploadedFile(__DIR__.'/Fixtures/sadkitten.gif', 'sadkitten.gif', 'image/gif');
+        $client = new Client($this->kernel);
+        $crawler = $client->request('GET', '/upload-form.php');
+
+        $form = $crawler ->selectButton('Submit')->form();
+        $crawler = $client->submit($form, array(
+            'file1' => $file,
+            'file2' => null
+        ));
+
+        $expected = implode("\n", array(
+            'sadkitten.gif',
+        ));
+        $this->assertSame($expected."\n", $client->getResponse()->getContent());
     }
 
     /** @test */

--- a/tests/functional/Fixtures/upload-form.php
+++ b/tests/functional/Fixtures/upload-form.php
@@ -1,0 +1,17 @@
+<?php
+if(isset($_POST['submit'])) {
+	echo $_FILES['file1']['name']."\n";
+	exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en" class="">
+<head></head>
+<body>
+	<form enctype="multipart/form-data" method="post">
+		<input type="file" name="file1" />
+		<input type="file" name="file2" />
+		<input type="submit" name="submit" value="Submit" />
+	</form>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes an annoying error due to missing check in empty "file" fields on form submit.

The error was:

``` bash
1) CgiHttpKernelTest::submitShouldUploadFiles
Argument 2 passed to Igorw\CgiHttpKernel\CgiHttpKernel::encodeMultipartFile() must be an instance of
 Symfony\Component\HttpFoundation\File\UploadedFile, null given, called in 
CgiHttpKernel/src/Igorw/CgiHttpKernel/CgiHttpKernel.php on line 221 and defined
```
